### PR TITLE
Add ProcessCommunicatorBase.write(GroupAddress,DPTXlator)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,0 @@
-language: java

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: java

--- a/src/tuwien/auto/calimero/process/ProcessCommunicationBase.java
+++ b/src/tuwien/auto/calimero/process/ProcessCommunicationBase.java
@@ -39,6 +39,7 @@ package tuwien.auto.calimero.process;
 import tuwien.auto.calimero.GroupAddress;
 import tuwien.auto.calimero.Priority;
 import tuwien.auto.calimero.datapoint.Datapoint;
+import tuwien.auto.calimero.dptxlator.DPTXlator;
 import tuwien.auto.calimero.exception.KNXException;
 import tuwien.auto.calimero.exception.KNXFormatException;
 import tuwien.auto.calimero.exception.KNXTimeoutException;
@@ -251,7 +252,7 @@ public interface ProcessCommunicationBase
 	 * <p>
 	 * Writes a 2-byte KNX float datapoint value to a group destination.
 	 * <p>
-	 * 
+	 *
 	 * @param dst group destination to write to
 	 * @param value float value to write
 	 * @throws KNXTimeoutException on a timeout during send
@@ -292,6 +293,18 @@ public interface ProcessCommunicationBase
 	 * @throws KNXException on other write problems
 	 */
 	void write(GroupAddress dst, String value) throws KNXException;
+
+	/**
+	 * Writes the content of the supplied DPTXlator to a group destination.
+	 *
+	 * @param dst group destination to write to
+	 * @param value DPTXlator which's value to write
+	 * @throws KNXTimeoutException on a timeout during send
+	 * @throws KNXFormatException on translation problem of the supplied datapoint value
+	 * @throws KNXLinkClosedException if network link to KNX network is closed
+	 * @throws KNXException on other write problems
+	 */
+	void write(GroupAddress dst, DPTXlator value) throws KNXException;
 
 	/**
 	 * Writes a datapoint value to a group destination.

--- a/src/tuwien/auto/calimero/process/ProcessCommunicatorImpl.java
+++ b/src/tuwien/auto/calimero/process/ProcessCommunicatorImpl.java
@@ -405,6 +405,16 @@ public class ProcessCommunicatorImpl implements ProcessCommunicator
 		write(dst, priority, t);
 	}
 
+	/* (non-Javadoc)
+	 * @see tuwien.auto.calimero.process.ProcessCommunicator#write
+	 * (tuwien.auto.calimero.GroupAddress, tuwien.auto.calimero.dptxlator.DPTXlator)
+	 */
+	public void write(final GroupAddress dst, final DPTXlator value) throws KNXTimeoutException,
+		KNXFormatException, KNXLinkClosedException
+	{
+		write(dst, priority, value);
+	}
+
 	/**
 	 * {@inheritDoc}
 	 * <p>


### PR DESCRIPTION
Add a new write() signature which takes a GroupAddress and a pre-set DPTXlator as an argument, to allow directly writing the contents of the DPTXlator to the bus.

Currently, there is no other way to do this but to duplicate the code of the private method ProcessCommunicatorImpl.write(GroupAddress,Priority,DPTXlator)