### PR TITLE
added getUnit() and base-class getNumericValue()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 
 # OS X
 .DS_Store
+/eclipsebuild/

--- a/src/tuwien/auto/calimero/dptxlator/DPTXlator.java
+++ b/src/tuwien/auto/calimero/dptxlator/DPTXlator.java
@@ -204,16 +204,6 @@ public abstract class DPTXlator
 	}
 
 	/**
-	 * If the subtype has a unit of measurement, return it.
-	 *
-	 * @return a string denoting the unit of measurement, or "" if no unit is known
-	 */
-	public String getUnit()
-	{
-		return dpt.getUnit();
-	}
-
-	/**
 	 * Get the numeric representation of the value, if the DPT value can be represented
 	 * numerically. Will throw an KNXFormatException if the value can not be represented
 	 * numerically.

--- a/src/tuwien/auto/calimero/dptxlator/DPTXlator.java
+++ b/src/tuwien/auto/calimero/dptxlator/DPTXlator.java
@@ -69,7 +69,7 @@ import tuwien.auto.calimero.log.LogService;
  * <p>
  * DPT translator implementations are not required to be thread safe. All translators
  * provided in this package are not thread safe.
- * 
+ *
  * @author B. Malinowsky
  */
 public abstract class DPTXlator
@@ -79,7 +79,7 @@ public abstract class DPTXlator
 	 * <p>
 	 */
 	public static final String LOG_SERVICE = "DPTXlator";
-	
+
 	/**
 	 * Logger object for all translators.
 	 * <p>
@@ -123,7 +123,7 @@ public abstract class DPTXlator
 
 	/**
 	 * Creates the new translator and initializes the data type size.
-	 * 
+	 *
 	 * @param dataTypeSize size in bytes of the KNX data type, use 0 if the type size
 	 *        &lt;= 6 bits
 	 */
@@ -140,7 +140,7 @@ public abstract class DPTXlator
 	 * they get stored by the translator, replacing any old items. On
 	 * <code>values.length == 0</code>, no action is performed.<br>
 	 * Textual commands contained in <code>values</code> are treated case insensitive.
-	 * 
+	 *
 	 * @param values string array holding values for translation
 	 * @throws KNXFormatException if an item in <code>values</code> can't be translated
 	 *         due to a wrong formatted content, or if <code>value</code>doesn't fit
@@ -162,7 +162,7 @@ public abstract class DPTXlator
 	 * <p>
 	 * The items are ordered the same way handed to the translator in the first place
 	 * (FIFO, increasing byte index).
-	 * 
+	 *
 	 * @return an array of strings with values represented as strings
 	 * @see #getValue()
 	 */
@@ -176,7 +176,7 @@ public abstract class DPTXlator
 	 * <code>value</code> are treated case insensitive.<br>
 	 * The <code>value</code> string might have its unit of measure appended (units are
 	 * case sensitive).
-	 * 
+	 *
 	 * @param value value represented as string for translation, case insensitive
 	 * @throws KNXFormatException if <code>value</code> can't be translated due to wrong
 	 *         formatted content, or if <code>value</code>doesn't fit into KNX data type
@@ -194,7 +194,7 @@ public abstract class DPTXlator
 	 * <p>
 	 * If the subtype has a unit of measurement, it is appended after the value according
 	 * to {@link DPTXlator#setAppendUnit(boolean)}.<br>
-	 * 
+	 *
 	 * @return a string representation of the value
 	 * @see #getType()
 	 */
@@ -204,9 +204,32 @@ public abstract class DPTXlator
 	}
 
 	/**
+	 * If the subtype has a unit of measurement, return it.
+	 *
+	 * @return a string denoting the unit of measurement, or "" if no unit is known
+	 */
+	public String getUnit()
+	{
+		return dpt.getUnit();
+	}
+
+	/**
+	 * Get the numeric representation of the value, if the DPT value can be represented
+	 * numerically. Will throw an KNXFormatException if the value can not be represented
+	 * numerically.
+	 *
+	 * @return the numeric representation of the value
+	 * @throws KNXFormatException
+	 */
+	public double getNumericValue() throws KNXFormatException
+	{
+		throw new KNXFormatException("No simple numeric representation possible");
+	}
+
+	/**
 	 * See {@link #setData(byte[], int)}, with offset 0.
 	 * <p>
-	 * 
+	 *
 	 * @param data byte array containing KNX DPT item(s)
 	 */
 	public final void setData(final byte[] data)
@@ -228,7 +251,7 @@ public abstract class DPTXlator
 	 * <code>data.length</code> will satisfy the minimum acceptable length. If this is
 	 * not the case, {@link KNXIllegalArgumentException} has to be caught and handled in
 	 * the caller's context.
-	 * 
+	 *
 	 * @param data byte array containing KNX DPT item(s)
 	 * @param offset offset into <code>data</code> from where to start, 0 &lt;= offset
 	 *        &lt; <code>data.length</code>
@@ -252,7 +275,7 @@ public abstract class DPTXlator
 	/**
 	 * Returns a copy of all items stored by this translator translated into DPTs.
 	 * <p>
-	 * 
+	 *
 	 * @return byte array with KNX DPT value items
 	 */
 	public byte[] getData()
@@ -270,7 +293,7 @@ public abstract class DPTXlator
 	 * modified.<br>
 	 * Datapoint types shorter than 1 bytes only change the affected lower bit positions,
 	 * leaving the upper (high) bits of <code>dst</code> bytes untouched.
-	 * 
+	 *
 	 * @param dst byte array for storing DPT values
 	 * @param offset offset into <code>dst</code> from where to start, 0 &lt;= offset
 	 *        &lt; <code>dst.length</code>
@@ -285,7 +308,7 @@ public abstract class DPTXlator
 		if (min > 0 && end == 0)
 			logger.warn(dpt.getID() + " insufficient space in destination range (" + min + " < "
 					+ typeSize + ")");
-		
+
 		for (int i = 0; i < end; ++i)
 			dst[offset + i] = (byte) data[i];
 		return dst;
@@ -297,7 +320,7 @@ public abstract class DPTXlator
 	 * <p>
 	 * Translator methods capable of appending an available DPT unit will act according
 	 * this setting.
-	 * 
+	 *
 	 * @param append <code>true</code> to append a DPT unit if any available,
 	 *        <code>false</code> to omit any unit
 	 */
@@ -309,7 +332,7 @@ public abstract class DPTXlator
 	/**
 	 * Returns the number of translation items currently in the translator.
 	 * <p>
-	 * 
+	 *
 	 * @return items number
 	 */
 	public int getItems()
@@ -323,7 +346,7 @@ public abstract class DPTXlator
 	 * <p>
 	 * The DPT distinguishes between the different subtypes available for a KNX data type.
 	 * It specifies the dimension, consisting of range and unit attributes.
-	 * 
+	 *
 	 * @return datapoint type in a {@link DPT}
 	 */
 	public final DPT getType()
@@ -346,7 +369,7 @@ public abstract class DPTXlator
 	 * Changes of the DPT currently used by the translator take effect on the next new
 	 * translator created using that DPT.<br>
 	 * The map itself is not synchronized.
-	 * 
+	 *
 	 * @return subtypes as {@link Map}, key is the subtype ID of type string, value of
 	 *         type {@link DPT}
 	 */
@@ -356,7 +379,7 @@ public abstract class DPTXlator
 	 * Returns the KNX data type size in bytes for one value item.
 	 * <p>
 	 * If the data type size is &lt;= 6 bits, 0 is returned.
-	 * 
+	 *
 	 * @return type size in bytes, 0 for types &lt;= 6 bits
 	 */
 	public final int getTypeSize()
@@ -371,7 +394,7 @@ public abstract class DPTXlator
 	 * The string consists of a list of values in the order they are returned by
 	 * {@link #getAllValues()}. Adjacent items are separated as specified by
 	 * {@link AbstractCollection#toString()}.
-	 * 
+	 *
 	 * @return a string representation of the translation values
 	 */
 	public String toString()
@@ -385,7 +408,7 @@ public abstract class DPTXlator
 	 * the item index of the value. The translated KNX data is stored at the corresponding
 	 * array offset in <code>dst</code>. Calculation of offset:
 	 * <code>offset = index * KNX data type size</code>.
-	 * 
+	 *
 	 * @param value value to translate
 	 * @param dst destination array for resulting KNX data
 	 * @param index item index in destination array
@@ -394,12 +417,12 @@ public abstract class DPTXlator
 	 *         type
 	 */
 	protected abstract void toDPT(String value, short[] dst, int index) throws KNXFormatException;
-	
+
 	/**
 	 * Sets the DPT for the translator to use for translation, doing a lookup before in
 	 * the translator's map containing the available, implemented datapoint types.
 	 * <p>
-	 * 
+	 *
 	 * @param availableTypes map of the translator with available, implemented DPTs; the
 	 *        map key is a dptID string, map value is of type {@link DPT}
 	 * @param dptID the ID as string of the datapoint type to set
@@ -427,7 +450,7 @@ public abstract class DPTXlator
 	 * hidden by declarations with the same signature in a sub type. A correct invocation
 	 * is done using the declared type that actually contains the method declaration
 	 * returning the available sub types.
-	 * 
+	 *
 	 * @return subtypes as {@link Map}, key is the subtype ID of type string, value of
 	 *         type {@link DPT}
 	 */
@@ -448,7 +471,7 @@ public abstract class DPTXlator
 	 * specified.
 	 * <p>
 	 * Whitespace are removed from both ends.
-	 * 
+	 *
 	 * @param value value string representation
 	 * @return trimmed value string without unit
 	 */
@@ -470,7 +493,7 @@ public abstract class DPTXlator
 	 * Helper which logs message and creates a format exception.
 	 * <p>
 	 * Adds the current dpt ID as prefix to log output.
-	 * 
+	 *
 	 * @param level log level
 	 * @param msg log output, exception message if <code>excMsg</code> is
 	 *        <code>null</code>

--- a/src/tuwien/auto/calimero/dptxlator/DPTXlator2ByteFloat.java
+++ b/src/tuwien/auto/calimero/dptxlator/DPTXlator2ByteFloat.java
@@ -57,7 +57,7 @@ import tuwien.auto.calimero.log.LogLevel;
  * Note, that the floating type structure specified by this data type isn't really
  * precise, especially for bigger floating numbers, so you have to expect certain rounding
  * deviations.
- * 
+ *
  * @author B. Malinowsky
  */
 public class DPTXlator2ByteFloat extends DPTXlator
@@ -164,7 +164,7 @@ public class DPTXlator2ByteFloat extends DPTXlator
 	 * <p>
 	 */
 	public static final DPT DPT_POWER = new DPT("9.024", "Power", "-670760", "+670760", "kW");
-	
+
 	/**
 	 * DPT ID 9.025, Volume flow in liter/hour; value range <b>+/-670760</b> l/h, resolution 0.01.
 	 * <p>
@@ -195,7 +195,7 @@ public class DPTXlator2ByteFloat extends DPTXlator
 	 */
 	public static final DPT DPT_WIND_SPEED_KMH = new DPT("9.028", "Wind speed ", "0", "670760.96",
 			"km/h");
-	
+
 	private static final Map types;
 
 	static {
@@ -227,7 +227,7 @@ public class DPTXlator2ByteFloat extends DPTXlator
 	/**
 	 * Creates a translator for the given datapoint type.
 	 * <p>
-	 * 
+	 *
 	 * @param dpt the requested datapoint type
 	 * @throws KNXFormatException on not supported or not available DPT
 	 */
@@ -239,7 +239,7 @@ public class DPTXlator2ByteFloat extends DPTXlator
 	/**
 	 * Creates a translator for <code>dptID</code>.
 	 * <p>
-	 * 
+	 *
 	 * @param dptID available implemented datapoint type ID
 	 * @throws KNXFormatException on wrong formatted or not expected (available) DPT
 	 */
@@ -256,7 +256,7 @@ public class DPTXlator2ByteFloat extends DPTXlator
 	 * Sets the translation value from a double.
 	 * <p>
 	 * If succeeded, any other items in the translator are discarded.
-	 * 
+	 *
 	 * @param value the double value
 	 * @throws KNXFormatException if <code>value</code>doesn't fit into KNX data type
 	 */
@@ -270,7 +270,7 @@ public class DPTXlator2ByteFloat extends DPTXlator
 	/**
 	 * Returns the first translation item formatted as float.
 	 * <p>
-	 * 
+	 *
 	 * @return value as float
 	 */
 	public final float getValueFloat()
@@ -281,12 +281,24 @@ public class DPTXlator2ByteFloat extends DPTXlator
 	/**
 	 * Returns the first translation item formatted as double.
 	 * <p>
-	 * 
+	 *
 	 * @return value as double
 	 */
 	public final double getValueDouble()
 	{
 		return fromDPT(0);
+	}
+
+	/**
+	 *  Returns the first translation item formatted as double.
+	 *
+	 *  @return numeric value
+	 *  @see tuwien.auto.calimero.dptxlator.DPTXlator#getNumericValue()
+	 *  @see getValueDouble()
+	 */
+	public final double getNumericValue()
+	{
+		return getValueDouble();
 	}
 
 	/* (non-Javadoc)

--- a/src/tuwien/auto/calimero/dptxlator/DPTXlator2ByteUnsigned.java
+++ b/src/tuwien/auto/calimero/dptxlator/DPTXlator2ByteUnsigned.java
@@ -122,7 +122,7 @@ public class DPTXlator2ByteUnsigned extends DPTXlator
 	 * <p>
 	 */
 	public static final DPT DPT_LENGTH = new DPT("7.011", "Length in mm", "0", "65535", "mm");
-	
+
 	/**
 	 * DPT ID 7.012, Electrical current; values from <b>0</b> to <b>65535</b> mA.
 	 * <p>
@@ -164,7 +164,7 @@ public class DPTXlator2ByteUnsigned extends DPTXlator
 	/**
 	 * Creates a translator for the given datapoint type.
 	 * <p>
-	 * 
+	 *
 	 * @param dpt the requested datapoint type
 	 * @throws KNXFormatException on not supported or not available DPT
 	 */
@@ -176,7 +176,7 @@ public class DPTXlator2ByteUnsigned extends DPTXlator
 	/**
 	 * Creates a translator for the given datapoint type ID.
 	 * <p>
-	 * 
+	 *
 	 * @param dptID available implemented datapoint type ID
 	 * @throws KNXFormatException on wrong formatted or not expected (available)
 	 *         <code>dptID</code>
@@ -206,7 +206,7 @@ public class DPTXlator2ByteUnsigned extends DPTXlator
 	 * a value of DPT_TIMEPERIOD_100 by 100. The result is rounded to the nearest
 	 * representable value (with 0.5 rounded up). On any other DPT the value is expected
 	 * according to its unit.
-	 * 
+	 *
 	 * @param value unsigned value, 0 &lt;= value &lt;= max, with
 	 *        <ul>
 	 *        <li>max = 655350 on DPT {@link #DPT_TIMEPERIOD_10}</li>
@@ -230,13 +230,31 @@ public class DPTXlator2ByteUnsigned extends DPTXlator
 	 * returned in unit millisecond, i.e., a KNX DPT_TIMEPERIOD_10 data value is multiplied
 	 * with 10, DPT_TIMEPERIOD_100 with 100.<br>
 	 * On any other DPT the value is returned according to its unit.
-	 * 
+	 *
 	 * @return value as unsigned 16 Bit using type int
 	 * @see #getType()
 	 */
 	public final int getValueUnsigned()
 	{
 		return fromDPT(0);
+	}
+
+	/**
+	 * Returns the first translation item as unsigned value.
+	 * <p>
+	 * A value of DPT {@link #DPT_TIMEPERIOD_10} or {@link #DPT_TIMEPERIOD_100} is
+	 * returned in unit millisecond, i.e., a KNX DPT_TIMEPERIOD_10 data value is multiplied
+	 * with 10, DPT_TIMEPERIOD_100 with 100.<br>
+	 * On any other DPT the value is returned according to its unit.
+	 *
+	 *  @return numeric value
+	 *  @see tuwien.auto.calimero.dptxlator.DPTXlator#getNumericValue()
+	 *  @see getValueUnsigned()
+	 */
+
+	public double getNumericValue()
+	{
+		return getValueUnsigned();
 	}
 
 	/* (non-Javadoc)
@@ -260,7 +278,7 @@ public class DPTXlator2ByteUnsigned extends DPTXlator
 	 * set DPT, with the result rounded to the nearest representable value (with 0.5
 	 * rounded up).<br>
 	 * On any other DPT, the input is treated equal to {@link #setValue(int)}.
-	 * 
+	 *
 	 * @param milliseconds the value in milliseconds, 0 &lt;= <code>milliseconds</code>
 	 * @throws KNXFormatException on milliseconds out of range for DPT
 	 */

--- a/src/tuwien/auto/calimero/dptxlator/DPTXlator4ByteFloat.java
+++ b/src/tuwien/auto/calimero/dptxlator/DPTXlator4ByteFloat.java
@@ -61,7 +61,7 @@ import tuwien.auto.calimero.log.LogLevel;
  * In value methods expecting a string type, the value is a float type representation.
  * <p>
  * The default return value after creation is <code>0.0</code>.<br>
- * 
+ *
  * @author B. Malinowsky
  */
 public class DPTXlator4ByteFloat extends DPTXlator
@@ -712,7 +712,7 @@ public class DPTXlator4ByteFloat extends DPTXlator
 	/**
 	 * Creates a translator for the given datapoint type.
 	 * <p>
-	 * 
+	 *
 	 * @param dpt the requested datapoint type
 	 * @throws KNXFormatException on not supported or not available DPT
 	 */
@@ -724,7 +724,7 @@ public class DPTXlator4ByteFloat extends DPTXlator
 	/**
 	 * Creates a translator for <code>dptID</code>.
 	 * <p>
-	 * 
+	 *
 	 * @param dptId available implemented datapoint type ID
 	 * @throws KNXFormatException on wrong formatted or not expected (available) DPT
 	 */
@@ -741,7 +741,7 @@ public class DPTXlator4ByteFloat extends DPTXlator
 	 * Sets the translation value from a float.
 	 * <p>
 	 * If succeeded, any other items in the translator are discarded.
-	 * 
+	 *
 	 * @param value the float value
 	 * @throws KNXFormatException if <code>value</code> doesn't fit into KNX data type
 	 */
@@ -755,12 +755,24 @@ public class DPTXlator4ByteFloat extends DPTXlator
 	/**
 	 * Returns the first translation item formatted as float.
 	 * <p>
-	 * 
+	 *
 	 * @return value as float
 	 */
 	public final float getValueFloat()
 	{
 		return fromDPT(0);
+	}
+
+	/**
+	 *  Returns the first translation item formatted as double.
+	 *
+	 *  @return numeric value
+	 *  @see tuwien.auto.calimero.dptxlator.DPTXlator#getNumericValue()
+	 *  @see getValueFloat()
+	 */
+	public final double getNumericValue()
+	{
+		return getValueFloat();
 	}
 
 	/* (non-Javadoc)

--- a/src/tuwien/auto/calimero/dptxlator/DPTXlator4ByteSigned.java
+++ b/src/tuwien/auto/calimero/dptxlator/DPTXlator4ByteSigned.java
@@ -127,7 +127,7 @@ public class DPTXlator4ByteSigned extends DPTXlator
 			"-2147483648", "2147483647", "s");
 
 	private static final Map types;
-	
+
 	static {
 		types = new HashMap(15);
 		final Field[] fields = DPTXlator4ByteSigned.class.getFields();
@@ -145,7 +145,7 @@ public class DPTXlator4ByteSigned extends DPTXlator
 	/**
 	 * Creates a translator for the given datapoint type.
 	 * <p>
-	 * 
+	 *
 	 * @param dpt the requested datapoint type
 	 * @throws KNXFormatException on not supported or not available DPT
 	 */
@@ -157,7 +157,7 @@ public class DPTXlator4ByteSigned extends DPTXlator
 	/**
 	 * Creates a translator for the given datapoint type ID.
 	 * <p>
-	 * 
+	 *
 	 * @param dptId available implemented datapoint type ID
 	 * @throws KNXFormatException on wrong formatted or not expected (available)
 	 *         <code>dptID</code>
@@ -172,7 +172,7 @@ public class DPTXlator4ByteSigned extends DPTXlator
 	/**
 	 * Sets the value of the first translation item.
 	 * <p>
-	 * 
+	 *
 	 * @param value signed value
 	 * @throws KNXFormatException on input value out of range for DPT
 	 * @see #getType()
@@ -185,7 +185,7 @@ public class DPTXlator4ByteSigned extends DPTXlator
 	/**
 	 * Returns the first translation item as signed 32 Bit value.
 	 * <p>
-	 * 
+	 *
 	 * @return signed 32 Bit value using type long
 	 * @see #getType()
 	 */
@@ -193,6 +193,19 @@ public class DPTXlator4ByteSigned extends DPTXlator
 	{
 		return fromDPT(0);
 	}
+
+	/**
+	 * Returns the first translation item as signed 32 Bit value.
+	 *
+	 *  @return numeric value
+	 *  @see tuwien.auto.calimero.dptxlator.DPTXlator#getNumericValue()
+	 *  @see getValueDouble()
+	 */
+	public final double getNumericValue()
+	{
+		return getValueSigned();
+	}
+
 
 	/* (non-Javadoc)
 	 * @see tuwien.auto.calimero.dptxlator.DPTXlator#getValue()

--- a/src/tuwien/auto/calimero/dptxlator/DPTXlator4ByteUnsigned.java
+++ b/src/tuwien/auto/calimero/dptxlator/DPTXlator4ByteUnsigned.java
@@ -74,7 +74,7 @@ public class DPTXlator4ByteUnsigned extends DPTXlator
 	/**
 	 * Creates a translator for the given datapoint type.
 	 * <p>
-	 * 
+	 *
 	 * @param dpt the requested datapoint type
 	 * @throws KNXFormatException on not supported or not available DPT
 	 */
@@ -86,7 +86,7 @@ public class DPTXlator4ByteUnsigned extends DPTXlator
 	/**
 	 * Creates a translator for the given datapoint type ID.
 	 * <p>
-	 * 
+	 *
 	 * @param dptID available implemented datapoint type ID
 	 * @throws KNXFormatException on wrong formatted or not expected (available)
 	 *         <code>dptID</code>
@@ -101,7 +101,7 @@ public class DPTXlator4ByteUnsigned extends DPTXlator
 	/**
 	 * Sets the value of the first translation item.
 	 * <p>
-	 * 
+	 *
 	 * @param value unsigned value, 0 &lt;= value &lt;= 0xFFFFFFFF
 	 * @throws KNXFormatException on input value out of range for DPT
 	 * @see #getType()
@@ -114,7 +114,7 @@ public class DPTXlator4ByteUnsigned extends DPTXlator
 	/**
 	 * Returns the first translation item as unsigned 32 Bit value.
 	 * <p>
-	 * 
+	 *
 	 * @return unsigned 32 Bit value using type long
 	 * @see #getType()
 	 */
@@ -122,6 +122,19 @@ public class DPTXlator4ByteUnsigned extends DPTXlator
 	{
 		return fromDPT(0);
 	}
+
+	/**
+	 * Returns the first translation item as unsigned 32 Bit value.
+	 *
+	 *  @return numeric value
+	 *  @see tuwien.auto.calimero.dptxlator.DPTXlator#getNumericValue()
+	 *  @see getValueDouble()
+	 */
+	public final double getNumericValue()
+	{
+		return getValueUnsigned();
+	}
+
 
 	/* (non-Javadoc)
 	 * @see tuwien.auto.calimero.dptxlator.DPTXlator#getValue()

--- a/src/tuwien/auto/calimero/dptxlator/DPTXlator8BitUnsigned.java
+++ b/src/tuwien/auto/calimero/dptxlator/DPTXlator8BitUnsigned.java
@@ -94,7 +94,7 @@ public class DPTXlator8BitUnsigned extends DPTXlator
 	 * 255: reserved, shall not be transmitted
 	 */
 	public static final DPT DPT_TARIFF = new DPT("5.006", "Tariff information", "0", "254");
-	
+
 	/**
 	 * DPT ID 5.010, Value 1 unsigned count; values from <b>0</b> to <b>255</b> counter
 	 * pulses.
@@ -118,7 +118,7 @@ public class DPTXlator8BitUnsigned extends DPTXlator
 	/**
 	 * Creates a translator for the given datapoint type.
 	 * <p>
-	 * 
+	 *
 	 * @param dpt the requested datapoint type
 	 * @throws KNXFormatException on not supported or not available DPT
 	 */
@@ -130,7 +130,7 @@ public class DPTXlator8BitUnsigned extends DPTXlator
 	/**
 	 * Creates a translator for the given datapoint type ID.
 	 * <p>
-	 * 
+	 *
 	 * @param dptID available implemented datapoint type ID
 	 * @throws KNXFormatException on wrong formatted or not expected (available)
 	 *         <code>dptID</code>
@@ -154,7 +154,7 @@ public class DPTXlator8BitUnsigned extends DPTXlator
 	 * items.
 	 * <p>
 	 * The scale of the input value is according to the current DPT.
-	 * 
+	 *
 	 * @param scaled scaled unsigned value, the dimension is determined by the set DPT, 0
 	 *        &lt;= scaled value &lt;= defined maximum of DPT
 	 * @throws KNXFormatException on wrong scaled value, if input doesn't conform to
@@ -170,7 +170,7 @@ public class DPTXlator8BitUnsigned extends DPTXlator
 	 * Returns the first translation item, the value scaled conforming to the range of the
 	 * set DPT.
 	 * <p>
-	 * 
+	 *
 	 * @return scaled representation as unsigned 8 Bit using type short
 	 * @see #getType()
 	 */
@@ -180,11 +180,24 @@ public class DPTXlator8BitUnsigned extends DPTXlator
 	}
 
 	/**
+	 * Returns the first translation item, the value scaled conforming to the range of the
+	 * set DPT.
+	 *
+	 *  @return scaled numeric value
+	 *  @see tuwien.auto.calimero.dptxlator.DPTXlator#getNumericValue()
+	 *  @see getValueUnsigned()
+	 */
+	public final double getNumericValue()
+	{
+		return getValueUnsigned();
+	}
+
+	/**
 	 * Sets one new translation item from an unsigned unscaled value, replacing any old
 	 * items.
 	 * <p>
 	 * No scaling is performed during translation, the value is equal to the raw KNX data.
-	 * 
+	 *
 	 * @param unscaled unscaled unsigned value, 0 &lt;= <code>unscaled</code> &lt;= 255,
 	 *        the higher bytes are ignored
 	 */
@@ -198,7 +211,7 @@ public class DPTXlator8BitUnsigned extends DPTXlator
 	 * <p>
 	 * The returned value is the raw KNX data value (0..255), not adjusted to the value
 	 * range of the set DPT.
-	 * 
+	 *
 	 * @return unscaled representation as unsigned byte
 	 */
 	public final short getValueUnscaled()
@@ -239,7 +252,7 @@ public class DPTXlator8BitUnsigned extends DPTXlator
 	 * <p>
 	 * The translator is reset into default state, all currently contained items are
 	 * removed (default value is set).
-	 * 
+	 *
 	 * @param dptID new subtype ID to set
 	 * @throws KNXFormatException on wrong formatted or not expected (available)
 	 *         <code>dptID</code>

--- a/src/tuwien/auto/calimero/dptxlator/DPTXlatorBoolean.java
+++ b/src/tuwien/auto/calimero/dptxlator/DPTXlatorBoolean.java
@@ -49,7 +49,7 @@ import tuwien.auto.calimero.log.LogLevel;
  * The KNX data type width is the lowest bit of 1 byte.<br>
  * The default return value after creation is <code>0</code>, i.e., <code>false</code>
  * for DPT Boolean for example.
- * 
+ *
  * @author B. Malinowsky
  */
 public class DPTXlatorBoolean extends DPTXlator
@@ -199,7 +199,7 @@ public class DPTXlatorBoolean extends DPTXlator
 	 * <p>
 	 */
 	public static final DPT DPT_HEAT_COOL = new DPT("1.100", "Heat/Cool", "cooling", "heating");
-	
+
 	private static final Map types;
 
 	static {
@@ -228,11 +228,11 @@ public class DPTXlatorBoolean extends DPTXlator
 		types.put(DPT_SHUTTER_BLINDS_MODE.getID(), DPT_SHUTTER_BLINDS_MODE);
 		types.put(DPT_HEAT_COOL.getID(), DPT_HEAT_COOL);
 	}
-	
+
 	/**
 	 * Creates a translator for the given datapoint type.
 	 * <p>
-	 * 
+	 *
 	 * @param dpt the requested datapoint type
 	 * @throws KNXFormatException on not supported or not available DPT
 	 */
@@ -244,7 +244,7 @@ public class DPTXlatorBoolean extends DPTXlator
 	/**
 	 * Creates a translator for the given datapoint type ID.
 	 * <p>
-	 * 
+	 *
 	 * @param dptID available implemented datapoint type ID
 	 * @throws KNXFormatException on wrong formatted or not expected (available)
 	 *         <code>dptID</code>
@@ -260,7 +260,7 @@ public class DPTXlatorBoolean extends DPTXlator
 	 * Sets the translation value from a boolean.
 	 * <p>
 	 * Any other items in the translator are discarded.
-	 * 
+	 *
 	 * @param value the boolean value
 	 */
 	public final void setValue(final boolean value)
@@ -271,7 +271,7 @@ public class DPTXlatorBoolean extends DPTXlator
 	/**
 	 * Returns the first translation item formatted as boolean.
 	 * <p>
-	 * 
+	 *
 	 * @return boolean representation
 	 */
 	public final boolean getValueBoolean()
@@ -296,6 +296,17 @@ public class DPTXlatorBoolean extends DPTXlator
 		for (int i = 0; i < data.length; ++i)
 			buf[i] = fromDPT(i);
 		return buf;
+	}
+
+	/**
+	 *  Returns 0 for boolean false and 1 for boolean true values
+	 *
+	 *  @return 0 or 1
+	 *  @see tuwien.auto.calimero.dptxlator.DPTXlator#getNumericValue()
+	 */
+	public double getNumericValue()
+	{
+		return getValueBoolean() ? 1 : 0;
 	}
 
 	/* (non-Javadoc)

--- a/src/tuwien/auto/calimero/dptxlator/DPTXlatorSceneNumber.java
+++ b/src/tuwien/auto/calimero/dptxlator/DPTXlatorSceneNumber.java
@@ -74,7 +74,7 @@ public class DPTXlatorSceneNumber extends DPTXlator
 	/**
 	 * Creates a translator for the given datapoint type.
 	 * <p>
-	 * 
+	 *
 	 * @param dpt the requested datapoint type
 	 * @throws KNXFormatException on not supported or not available DPT
 	 */
@@ -86,7 +86,7 @@ public class DPTXlatorSceneNumber extends DPTXlator
 	/**
 	 * Creates a translator for the given datapoint type ID.
 	 * <p>
-	 * 
+	 *
 	 * @param dptID available implemented datapoint type ID
 	 * @throws KNXFormatException on wrong formatted or not expected (available) <code>dptID</code>
 	 */
@@ -108,7 +108,7 @@ public class DPTXlatorSceneNumber extends DPTXlator
 	/**
 	 * Sets one new translation item, replacing any old items.
 	 * <p>
-	 * 
+	 *
 	 * @param scene number, 0 &lt;= scene number &lt;= 63
 	 */
 	public final void setValue(final int scene)
@@ -119,12 +119,22 @@ public class DPTXlatorSceneNumber extends DPTXlator
 	/**
 	 * Returns the scene number of the first translation item.
 	 * <p>
-	 * 
+	 *
 	 * @return unsigned 6 Bit using type short
 	 */
 	public final short getSceneNumber()
 	{
 		return (short) (data[0] & 0x3F);
+	}
+
+	/**
+	 * Returns the scene number of the first translation item.
+	 *
+	 * @return the scene number
+	 */
+	public final double getNumericValue()
+	{
+		return getSceneNumber();
 	}
 
 	/* (non-Javadoc)


### PR DESCRIPTION
-- added DTPXlator.getUnit() to get the string denoting the DPT's unit of measurement individually (even if appendUnit is set to false). 

Rationale: Useful if value and unit are handled independently. No impact on existing API.

-- added a double getNumericValue() method in DPTXlator, which returns a numeric representation of the first value, if possible. Throws KNXFormatException if no numeric representation is available.

Rationale: Currently, there is no base-class method to get the numeric representation of a DPT value, although most of them actually deal with numeric values. There is getValueFloat(), getValueSigned(), getValueUnsigned() etc. in the individual subclasses, but no common base-class method which can be called without prior type identification and casting. Useful when using the unspecialized DPTxlator base class. No impact on existing APIs.